### PR TITLE
fix: ensure derived wallet consistently rehydrates on page refresh

### DIFF
--- a/packages/snap/src/core/StateManager.ts
+++ b/packages/snap/src/core/StateManager.ts
@@ -16,6 +16,7 @@ export type State = {
   activeNetwork: Network;
   importedWallets: ImportedWallet[];
   activeImportedWallet?: string;
+  derivedWalletAddress?: string;
 };
 
 /**
@@ -47,6 +48,7 @@ export const DEFAULT_STATE: State = {
   activeNetwork: DEFAULT_NETWORKS[0] as Network,
   importedWallets: [],
   activeImportedWallet: undefined,
+  derivedWalletAddress: undefined,
 };
 
 export class StateManager {

--- a/packages/snap/src/handler/account/ListWalletsHandler.ts
+++ b/packages/snap/src/handler/account/ListWalletsHandler.ts
@@ -24,6 +24,11 @@ export class ListWalletsHandler implements IHandler<typeof ListWalletsMethod> {
       isActive: !state.activeImportedWallet, // Active if no imported wallet is selected
     };
 
+    // Ensure the derived wallet address is stored in state for future rehydration
+    if (!state.derivedWalletAddress || state.derivedWalletAddress !== derivedWallet.address) {
+      await this.context.stateManager.set({ derivedWalletAddress: derivedWallet.address });
+    }
+
     // Get imported wallets info
     const importedWallets: WalletInfo[] = state.importedWallets.map((w) => ({
       address: w.address,


### PR DESCRIPTION
## Problem
The derived wallet is not being consistently rehydrated on page refresh once it becomes funded. This happens because the app's rehydration process is heavily geared toward imported wallets, and we never truly "store" the derived wallet in Snap state.

## Solution
This PR implements a fix to ensure proper rehydration of the derived wallet by:

1. Adding `derivedWalletAddress` to state tracking to maintain derived wallet state
2. Properly handling derived wallet selection and state updates in `Context.ts`
3. Ensuring derived wallet address is consistently stored during wallet listing
4. Improving error handling for imported wallet failures to properly fall back to derived wallet

## Changes
- Added `derivedWalletAddress` field to `State` type
- Updated `Context.init()` to store and track derived wallet address
- Enhanced `updateActiveWallet()` to properly handle derived wallet selection
- Updated `ListWalletsHandler` to ensure derived wallet state consistency
- Improved error handling for imported wallet initialization failures

## Testing
Please test the following scenarios:
1. Page refresh with unfunded derived wallet
2. Page refresh with funded derived wallet
3. Switching between imported and derived wallets
4. Page refresh after wallet switches
5. Error cases with imported wallet initialization