### PR TITLE
Fix: Sayfer finding | SAY-03 | State Update during the Read-Only Endpoint Call

### DIFF
--- a/packages/snap/src/handler/account/ListWalletsHandler.ts
+++ b/packages/snap/src/handler/account/ListWalletsHandler.ts
@@ -24,11 +24,6 @@ export class ListWalletsHandler implements IHandler<typeof ListWalletsMethod> {
       isActive: !state.activeImportedWallet, // Active if no imported wallet is selected
     };
 
-    // Ensure the derived wallet address is stored in state for future rehydration
-    if (!state.derivedWalletAddress || state.derivedWalletAddress !== derivedWallet.address) {
-      await this.context.stateManager.set({ derivedWalletAddress: derivedWallet.address });
-    }
-
     // Get imported wallets info
     const importedWallets: WalletInfo[] = state.importedWallets.map((w) => ({
       address: w.address,


### PR DESCRIPTION
Sayfer finding | SAY-03 | State Update during the Read-Only Endpoint Call

Fix:
Resolved issue by removing the redundant state write operation from the ListWalletsHandler