### PR TITLE
Fix: Sayfer finding | SAY-05 | Incorrect Regex

### DIFF
--- a/packages/snap/src/core/Wallet.ts
+++ b/packages/snap/src/core/Wallet.ts
@@ -70,7 +70,7 @@ export class Wallet {
       }
 
       // Remove any prefixes if present and ensure uppercase
-      const cleanPrivateKey = privateKey.replace(/^00|s/, '').toUpperCase();
+      const cleanPrivateKey = privateKey.replace(/^(?:00|s)/, '').toUpperCase();
       
       try {
         // First try to treat it as a seed without the 's' prefix


### PR DESCRIPTION
Sayfer finding | SAY-05 | Incorrect Regex

Fix:
Resolved issue by updating the regex pattern from /^00|s/ to /^(?:00|s)/.